### PR TITLE
add Fixer Drupal/blank_line_after_start_of_class (#7)

### DIFF
--- a/config/drupal/phpcsfixer.rules.yml
+++ b/config/drupal/phpcsfixer.rules.yml
@@ -35,6 +35,7 @@ parameters:
             case: upper
         declare_equal_normalize:
             space: single
+        Drupal/blank_line_after_start_of_class: true
         Drupal/blank_line_before_end_of_class: true
         Drupal/control_structure_braces_else: true
         Drupal/inline_comment_spacer: true

--- a/src/Config/Drupal.php
+++ b/src/Config/Drupal.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace drupol\PhpCsFixerConfigsDrupal\Config;
 
+use drupol\PhpCsFixerConfigsDrupal\Fixer\BlankLineAfterStartOfClass;
 use drupol\PhpCsFixerConfigsDrupal\Fixer\BlankLineBeforeEndOfClass;
 use drupol\PhpCsFixerConfigsDrupal\Fixer\ControlStructureCurlyBracketsElseFixer;
 use drupol\PhpCsFixerConfigsDrupal\Fixer\InlineCommentSpacerFixer;
@@ -43,6 +44,7 @@ final class Drupal extends YamlConfig
         $this
             ->registerCustomFixers([
                 new BlankLineBeforeEndOfClass($this->getIndent(), $this->getLineEnding()),
+                new BlankLineAfterStartOfClass($this->getIndent(), $this->getLineEnding()),
                 new ControlStructureCurlyBracketsElseFixer($this->getIndent(), $this->getLineEnding()),
                 new InlineCommentSpacerFixer(),
                 new TryCatchBlock($this->getIndent(), $this->getLineEnding()),

--- a/src/Config/Drupal.php
+++ b/src/Config/Drupal.php
@@ -43,8 +43,8 @@ final class Drupal extends YamlConfig
 
         $this
             ->registerCustomFixers([
-                new BlankLineBeforeEndOfClass($this->getIndent(), $this->getLineEnding()),
                 new BlankLineAfterStartOfClass($this->getIndent(), $this->getLineEnding()),
+                new BlankLineBeforeEndOfClass($this->getIndent(), $this->getLineEnding()),
                 new ControlStructureCurlyBracketsElseFixer($this->getIndent(), $this->getLineEnding()),
                 new InlineCommentSpacerFixer(),
                 new TryCatchBlock($this->getIndent(), $this->getLineEnding()),

--- a/src/Fixer/BlankLineAfterStartOfClass.php
+++ b/src/Fixer/BlankLineAfterStartOfClass.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace drupol\PhpCsFixerConfigsDrupal\Fixer;
+
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Tokenizer\TokensAnalyzer;
+use PhpCsFixer\WhitespacesFixerConfig;
+use SplFileInfo;
+
+use const T_WHITESPACE;
+
+final class BlankLineAfterStartOfClass implements FixerInterface, WhitespacesAwareFixerInterface
+{
+    /**
+     * @var \PhpCsFixer\WhitespacesFixerConfig
+     */
+    private $whitespacesConfig;
+
+    /**
+     * BlankLineAfterStatementFixer constructor.
+     *
+     * @param mixed $indent
+     * @param mixed $lineEnding
+     */
+    public function __construct($indent, $lineEnding)
+    {
+        $this->setWhitespacesConfig(
+            new WhitespacesFixerConfig($indent, $lineEnding)
+        );
+    }
+
+    public function fix(SplFileInfo $file, Tokens $tokens): void
+    {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isClassy()) {
+                continue;
+            }
+
+            $indexOpenCurlyBrace = $tokens->getNextTokenOfKind($index, ['{']);
+            $tokens->insertAt($indexOpenCurlyBrace + 1, new Token([T_WHITESPACE, $this->whitespacesConfig->getLineEnding()]));
+        }
+    }
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'A class must have a blank line after the first closing brace.',
+            [
+                new CodeSample(
+                    ''
+                ),
+            ]
+        );
+    }
+
+    public function getName(): string
+    {
+        return 'Drupal/blank_line_after_start_of_class';
+    }
+
+    public function getPriority(): int
+    {
+        return -10000;
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return true;
+    }
+
+    public function isRisky(): bool
+    {
+        return false;
+    }
+
+    public function setWhitespacesConfig(WhitespacesFixerConfig $config): void
+    {
+        $this->whitespacesConfig = $config;
+    }
+
+    public function supports(SplFileInfo $file): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
Add a new Fixer nammed `Drupal/blank_line_after_start_of_class` that fix #7.

> With PHPCS Fixer 3.13.1, the blank line after class opening is removed and this is not a manageable behavior with PHPCS Fixer rules options.

Fixes #7.
