### PR TITLE
Issue #20: Enable declare_strict_types without spaces around equal for Drupal8.

### DIFF
--- a/config/drupal8/phpcsfixer.rules.yml
+++ b/config/drupal8/phpcsfixer.rules.yml
@@ -2,5 +2,6 @@ parameters:
   rules:
     array_syntax:
       syntax: short
-    declare_strict_types: false
+    declare_equal_normalize: true
+    declare_strict_types: true
     blank_lines_before_namespace: false

--- a/tests/FixerTestCase.php
+++ b/tests/FixerTestCase.php
@@ -24,7 +24,7 @@ abstract class FixerTestCase extends TestCase
     /**
      * Run the Fixer tests.
      */
-    protected function doTest(string $expected, string $input = null): void
+    protected function doTest(string $expected, ?string $input = null): void
     {
         if (null === $input) {
             $input = $expected;

--- a/tests/Unit/Config/Drupal8Test.php
+++ b/tests/Unit/Config/Drupal8Test.php
@@ -109,11 +109,9 @@ final class Drupal8Test extends TestCase
                 'position' => 'next_line',
             ],
             'date_time_immutable' => false,
-            'declare_equal_normalize' => [
-                'space' => 'single',
-            ],
+            'declare_equal_normalize' => true,
             'declare_parentheses' => true,
-            'declare_strict_types' => false,
+            'declare_strict_types' => true,
             'dir_constant' => true,
             'doctrine_annotation_array_assignment' => [
                 'operator' => ':',

--- a/tests/Unit/Fixer/BlankLineAfterStartOfClassFixerTest.php
+++ b/tests/Unit/Fixer/BlankLineAfterStartOfClassFixerTest.php
@@ -29,7 +29,7 @@ final class BlankLineAfterStartOfClassFixerTest extends FixerTestCase
     /**
      * @dataProvider provideFixCases
      */
-    public function testFix(string $expected, string $input = null): void
+    public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Unit/Fixer/BlankLineBeforeEndOfClassFixerTest.php
+++ b/tests/Unit/Fixer/BlankLineBeforeEndOfClassFixerTest.php
@@ -31,7 +31,7 @@ final class BlankLineBeforeEndOfClassFixerTest extends FixerTestCase
     /**
      * @dataProvider provideFixCases
      */
-    public function testFix(string $expected, string $input = null): void
+    public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Unit/Fixer/ControlStructureCurlyBracketsElseFixerTest.php
+++ b/tests/Unit/Fixer/ControlStructureCurlyBracketsElseFixerTest.php
@@ -32,7 +32,7 @@ final class ControlStructureCurlyBracketsElseFixerTest extends FixerTestCase
     /**
      * @dataProvider provideFixCases
      */
-    public function testFix(string $expected, string $input = null): void
+    public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
@@ -121,7 +121,7 @@ else if ($y): bar(); endif;',
     /**
      * @dataProvider provideWithElseCases
      */
-    public function testWithElse(string $expected, string $input = null): void
+    public function testWithElse(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
@@ -174,7 +174,7 @@ else if ($y): bar(); endif;',
     /**
      * @dataProvider provideWithElseIfCases
      */
-    public function testWithElseIf(string $expected, string $input = null): void
+    public function testWithElseIf(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Unit/Fixer/InlineCommentSpacerFixerTest.php
+++ b/tests/Unit/Fixer/InlineCommentSpacerFixerTest.php
@@ -29,7 +29,7 @@ final class InlineCommentSpacerFixerTest extends FixerTestCase
     /**
      * @dataProvider provideFixCases
      */
-    public function testFix(string $expected, string $input = null): void
+    public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Unit/Fixer/TryCatchFinallyBlockFixerTest.php
+++ b/tests/Unit/Fixer/TryCatchFinallyBlockFixerTest.php
@@ -32,7 +32,7 @@ final class TryCatchFinallyBlockFixerTest extends FixerTestCase
     /**
      * @dataProvider provideWithTryCatchCases
      */
-    public function testWithTryCatch(string $expected, string $input = null): void
+    public function testWithTryCatch(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
@@ -73,7 +73,7 @@ final class TryCatchFinallyBlockFixerTest extends FixerTestCase
     /**
      * @dataProvider provideWithFinallyCases
      */
-    public function testWithFinally(string $expected, string $input = null): void
+    public function testWithFinally(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }


### PR DESCRIPTION
This PR

Fixes #20 .
