### PR TITLE
Issue #25: enable ordered_imports.case_sensitive by default since Drupal Coder (8.3.25) is now enforcing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - add running tests on PHP 8.3
 - add rule declare_equal_normalize to support declare(strict_types=1) without spaces around equal for Drupal8
+- enable ordered_imports.case_sensitive by default since Drupal Coder (8.3.25) is now enforcing it
 
 ## [2.1.0] - 2023-10-23
 ### Added

--- a/config/drupal/phpcsfixer.rules.yml
+++ b/config/drupal/phpcsfixer.rules.yml
@@ -87,6 +87,13 @@ parameters:
             allow_mixed: true
             allow_unused_params: true
             remove_inheritdoc: false
+        ordered_imports:
+            case_sensitive: true
+            imports_order:
+                - class
+                - function
+                - const
+            sort_algorithm: alpha
         phpdoc_add_missing_param_annotation: false
         single_line_comment_style: true
         single_quote:

--- a/tests/Integration/Scenario7Test.php
+++ b/tests/Integration/Scenario7Test.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace drupol\PhpCsFixerConfigsDrupal\Tests\Integration;
+
+use drupol\PhpCsFixerConfigsDrupal\Config\Drupal8;
+use drupol\PhpCsFixerConfigsDrupal\Tests\IntegrationTestCase;
+use PhpCsFixer\FixerFactory;
+use PhpCsFixer\RuleSet\RuleSet;
+
+/**
+ * @author Kevin Wenger <wenger.kev@gmail.com>
+ *
+ * Covers the PHP-CS-Fixer rules ordered_imports.case_sensitive
+ *
+ * @internal
+ */
+final class Scenario7Test extends IntegrationTestCase
+{
+    protected function getScenarioPath(): string
+    {
+        return __DIR__ . '/fixtures/scenario7';
+    }
+
+    public function testDrupal8Config(): void
+    {
+        $drupal8 = new Drupal8();
+        $rules = $drupal8->getRules();
+        $ruleset = new RuleSet($rules);
+
+        $factory = (new FixerFactory())
+            ->registerBuiltInFixers()
+            ->registerCustomFixers($drupal8->getCustomFixers())
+            ->useRuleSet($ruleset);
+
+        $fixers = [];
+        foreach ($factory->getFixers() as $fixer) {
+            $fixers[$fixer->getName()] = $fixer;
+        }
+
+        $this->doTest($fixers);
+    }
+}

--- a/tests/Integration/fixtures/scenario7/bad.php
+++ b/tests/Integration/fixtures/scenario7/bad.php
@@ -1,0 +1,16 @@
+<?php
+
+use foo\Bar;
+use Foo\Bar;
+
+namespace foo;
+
+class Bar {
+
+}
+
+namespace Foo;
+
+class Bar {
+
+}

--- a/tests/Integration/fixtures/scenario7/good.php
+++ b/tests/Integration/fixtures/scenario7/good.php
@@ -1,0 +1,16 @@
+<?php
+
+use Foo\Bar;
+use foo\Bar;
+
+namespace foo;
+
+class Bar {
+
+}
+
+namespace Foo;
+
+class Bar {
+
+}

--- a/tests/Unit/Config/Drupal7Test.php
+++ b/tests/Unit/Config/Drupal7Test.php
@@ -316,6 +316,7 @@ final class Drupal7Test extends TestCase
                 'sort_algorithm' => 'alpha',
             ],
             'ordered_imports' => [
+                'case_sensitive' => true,
                 'imports_order' => [
                     0 => 'class',
                     1 => 'function',

--- a/tests/Unit/Config/Drupal8Test.php
+++ b/tests/Unit/Config/Drupal8Test.php
@@ -316,6 +316,7 @@ final class Drupal8Test extends TestCase
                 'sort_algorithm' => 'alpha',
             ],
             'ordered_imports' => [
+                'case_sensitive' => TRUE,
                 'imports_order' => [
                     0 => 'class',
                     1 => 'function',

--- a/tests/Unit/Config/Drupal8Test.php
+++ b/tests/Unit/Config/Drupal8Test.php
@@ -316,7 +316,7 @@ final class Drupal8Test extends TestCase
                 'sort_algorithm' => 'alpha',
             ],
             'ordered_imports' => [
-                'case_sensitive' => TRUE,
+                'case_sensitive' => true,
                 'imports_order' => [
                     0 => 'class',
                     1 => 'function',


### PR DESCRIPTION
This PR

Fixes #25.
