### PR TITLE
enable rule fully_qualified_strict_types.phpdoc_tags = \[] to prevent php-cs-fixer stripping Namespaces out of comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add running tests on PHP 8.3
 - add rule declare_equal_normalize to support declare(strict_types=1) without spaces around equal for Drupal8
 - enable ordered_imports.case_sensitive by default since Drupal Coder (8.3.25) is now enforcing it
+- enable rule fully_qualified_strict_types.phpdoc_tags = \[] to prevent php-cs-fixer stripping Namespaces out of comments
 
 ## [2.1.0] - 2023-10-23
 ### Added

--- a/config/drupal8/phpcsfixer.rules.yml
+++ b/config/drupal8/phpcsfixer.rules.yml
@@ -7,3 +7,4 @@ parameters:
     blank_lines_before_namespace: false
     fully_qualified_strict_types:
         leading_backslash_in_global_namespace: false
+        phpdoc_tags: []

--- a/tests/Integration/Scenario8Test.php
+++ b/tests/Integration/Scenario8Test.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace drupol\PhpCsFixerConfigsDrupal\Tests\Integration;
+
+use drupol\PhpCsFixerConfigsDrupal\Config\Drupal8;
+use drupol\PhpCsFixerConfigsDrupal\Tests\IntegrationTestCase;
+use PhpCsFixer\FixerFactory;
+use PhpCsFixer\RuleSet\RuleSet;
+
+/**
+ * @author Kevin Wenger <wenger.kev@gmail.com>
+ *
+ * Covers the PHP-CS-Fixer rules fully_qualified_strict_types.phpdoc_tags
+ *
+ * @internal
+ */
+final class Scenario8Test extends IntegrationTestCase
+{
+    protected function getScenarioPath(): string
+    {
+        return __DIR__ . '/fixtures/scenario8';
+    }
+
+    public function testDrupal8Config(): void
+    {
+        $drupal8 = new Drupal8();
+        $rules = $drupal8->getRules();
+        $ruleset = new RuleSet($rules);
+
+        $factory = (new FixerFactory())
+            ->registerBuiltInFixers()
+            ->registerCustomFixers($drupal8->getCustomFixers())
+            ->useRuleSet($ruleset);
+
+        $fixers = [];
+        foreach ($factory->getFixers() as $fixer) {
+            $fixers[$fixer->getName()] = $fixer;
+        }
+
+        $this->doTest($fixers);
+    }
+}

--- a/tests/Integration/fixtures/scenario8/bad.php
+++ b/tests/Integration/fixtures/scenario8/bad.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Foo;
+
+class Bar {
+
+}
+
+class Baz {
+
+    /**
+     * @var \Foo\Bar $bar
+     *    The Bar class.
+     */
+    private Bar $bar;
+
+}

--- a/tests/Integration/fixtures/scenario8/good.php
+++ b/tests/Integration/fixtures/scenario8/good.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Foo;
+
+class Bar {
+
+}
+
+class Baz {
+
+    /**
+     * @var \Foo\Bar
+     *    The Bar class.
+     */
+    private Bar $bar;
+
+}

--- a/tests/Unit/Config/Drupal8Test.php
+++ b/tests/Unit/Config/Drupal8Test.php
@@ -150,6 +150,7 @@ final class Drupal8Test extends TestCase
             'full_opening_tag' => true,
             'fully_qualified_strict_types' => [
                 'leading_backslash_in_global_namespace' => false,
+                'phpdoc_tags' => [],
             ],
             'function_declaration' => [
                 'closure_function_spacing' => 'one',


### PR DESCRIPTION
enable rule `fully_qualified_strict_types.phpdoc_tags = []` to prevent php-cs-fixer stripping Namespaces out of comments

This PR close #24 